### PR TITLE
Making apls working with networkx 2.4

### DIFF
--- a/apls/apls_utils.py
+++ b/apls/apls_utils.py
@@ -192,7 +192,7 @@ def G_to_kdtree(G_, x_coord='x', y_coord='y', verbose=False):
     # populate node array
     t1 = time.time()
     for i, n in enumerate(G_.nodes()):
-        n_props = G_.node[n]
+        n_props = G_.nodes[n]
         if x_coord == 'lon':
             lat, lon = n_props['lat'], n_props['lon']
             x, y = lon, lat

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,6 @@ dependencies:
   - geopandas=0.5.0
   - opencv=3.4.4
   - numpy=1.16.3
-  - gdal=2.4.0
   - rtree=0.8.3
   - networkx=2.3
   - rasterio=1.0.22
@@ -19,3 +18,4 @@ dependencies:
   - scikit-image=0.15.0
   - pip:
     - affine==2.2.2
+    - GDAL>=2.2.0

--- a/environment.yml
+++ b/environment.yml
@@ -12,10 +12,10 @@ dependencies:
   - opencv=3.4.4
   - numpy=1.16.3
   - rtree=0.8.3
-  - networkx=2.3
   - rasterio=1.0.22
   - scipy=1.2.1
   - scikit-image=0.15.0
   - pip:
     - affine==2.2.2
     - GDAL>=2.2.0
+    - networkx>=2.4


### PR DESCRIPTION
I had a hard time to install apls to work properly because GDAL is very hard to install with correct version of `2.4.0`. Heveby, I proposes two changes to make it easier to install.

- relaxing requirements of GDAL
- changing G_.node -> G_.nodes for apls working in networkx>=2.4

Please let me know if any helps further needed. 